### PR TITLE
Per page 100 instead of default 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 ## Usage
 
+### Docker
+`docker run --rm -ti -e gyazo_access_token=xxxxx -w /root -v $PWD:/root python:3-alpine sh -c "pip install -r requirements.txt && python main.py"`
+
 ### MacOS
 - `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 - `brew install python3`
 - `pip install -r requirements.txt`
-- `export gyazo_access_token=XXXXX && python main.py`
+- `gyazo_access_token=XXXXX && python main.py`

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ def getGyazoImagesData(fetch):
         page = 0
         while True:
             page += 1
-            api_path = "https://api.gyazo.com/api/images?access_token=%s&page=%s" % (os.environ.get('gyazo_access_token'), page)
+            api_path = "https://api.gyazo.com/api/images?access_token=%s&per_page=100&page=%s" % (os.environ.get('gyazo_access_token'), page)
             print(api_path)
             gyazo_res = requests.get(api_path)
             # 2xx以外だったら止める


### PR DESCRIPTION
In my case, 5,112 images account, 
default (per_page=20) -> 257 pages, took 177s
per_page=100 -> 53 pages. took 42s (x4.2 speed up)

reference: https://gyazo.com/api/docs/image#list